### PR TITLE
Updated to perform standard bcftools filtering first

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,14 @@ sanitise_shire_output.py
 # TXT file of file comparisons
 *.txt
 
-# Plotting script
+# Scripts
 plotting.py
+add_routine_filter_variants_to_excel.py
+
+# Folders
+routine_filtered/
+optimised_filtered/
+optimised_filtered_split/
 
 # Excel
 *.xlsx

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Optimised filtering is a tool used to add a flag to indicate variants which:
 - Pass standard filtering with bcftools
 - Do not exceed gnomAD AF thresholds based on the gene's MOI (from PanelApp)
 - Fit the required zygosity counts (of those passing AF thresholds based on the gene's MOI)
- - E.g. a biallelic gene requires at least 1 homozygous variant or at least 2 heterozygous variants
+    - E.g. a biallelic gene requires at least 1 homozygous variant or at least 2 heterozygous variants
 
 ## Description
 The flag values which could be added to a variant:

--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ usage: add_optimised_filtering.py {ARGUMENTS}
 
 arguments:
  --input_vcf/-i [str]        Path to the input annotated VCF
- --config/-c [str]           DNAnexus file ID of config file containing filtering rules
+ --config/-c [str]           Path to the config file
  --panel_string/-p [str]     The panel(s) the patient is being tested for
- --genepanels/-g [str]       DNAnexus file ID of the genepanels file containing panel ID
- --panel_dump/-d [str]       DNAnexus file ID of a dump from PanelApp in JSON format
+ --genepanels/-g [str]       Path to the genepanels file containing panel IDs
+ --panel_dump/-d [str]       Path to the dump from PanelApp in JSON format
 ```
 
 
@@ -74,8 +74,8 @@ Example:
 ```
 python3 add_optimised_filtering.py \
 -i X123456_markdup_recalibrated_Haplotyper_annotated.vcf.gz \
--c project-GVqVPk04p65vjXb2kj6FqFKf:file-GYfv8V84p65bxXp1G8k5g44j \
+-c filter_config.json \
 -p 'R149.1_Severe early-onset obesity_P' \
--g project-GVqVPk04p65vjXb2kj6FqFKf:file-GY4QyKj4p65jx1xJqZKXBV79 \
--d project-GVqVPk04p65vjXb2kj6FqFKf:file-GY4QxJ04p65zJf3937y01XBP
+-g 230602_gp_panelapp_id.tsv \
+-d 230726_panelapp_dump.json
 ```

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # optimised_filtering
-Optimised filtering is a tool used to add a flag to variants which:
+Optimised filtering is a tool used to add a flag to indicate variants which:
 - Pass standard filtering with bcftools
-- Are within gnomAD AF thresholds based on the gene's MOI (from PanelApp)
+- Do not exceed gnomAD AF thresholds based on the gene's MOI (from PanelApp)
 - Fit the required zygosity counts (of those passing AF thresholds based on the gene's MOI)
  - E.g. a biallelic gene requires at least 1 homozygous variant or at least 2 heterozygous variants
 
 ## Description
-A flag which might be given to a variant:
+The flag values which could be added to a variant:
 - `PRIORITISED`: The variant passes filtering
 - `NOT_PRIORITISED`: The variant does not pass filtering
 - `NOT_ASSESSED`: The variant has not been assessed, either because:
@@ -56,15 +56,19 @@ A config JSON file is required, which is given as an argument to the tool as a D
 ```
 
 ## Usage
-The tool takes a VCF which has been annotated with VEP, and produces a VCF with two additional INFO fields. These are the name of your flag (as specified in the config) and the `Filter_reason`.
-The tool can be run as follows:
+The tool takes a VCF which has been annotated with VEP and produces a VCF with the two additional INFO fields specified above. The tool can be run as follows:
+
 ```
-python3 add_optimised_filtering.py \
--i <vcf> -c <config-file-id> \
--p <panel_string> \
--g <genepanels-file-id> \
--d <panelapp-dump-file-id>
+usage: add_optimised_filtering.py {ARGUMENTS}
+
+arguments:
+ --input_vcf/-i [str]        Path to the input annotated VCF
+ --config/-c [str]           DNAnexus file ID of config file containing filtering rules
+ --panel_string/-p [str]     The panel(s) the patient is being tested for
+ --genepanels/-g [str]       DNAnexus file ID of the genepanels file containing panel ID
+ --panel_dump/-d [str]       DNAnexus file ID of a dump from PanelApp in JSON format
 ```
+
 
 For example:
 ```

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ A config JSON file is required, which is given as an argument to the tool as a D
 ```
 
 ## Usage
+The tool takes a VCF which has been annotated with VEP, and produces a VCF with two additional INFO fields. These are the name of your flag (as specified in the config) and the `Filter_reason`.
 The tool can be run as follows:
 ```
 python3 add_optimised_filtering.py \

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ The flag values which could be added to a variant:
 - `PRIORITISED`: The variant passes filtering
 - `NOT_PRIORITISED`: The variant does not pass filtering
 - `NOT_ASSESSED`: The variant has not been assessed, either because:
- - The gene could not be found in the PanelApp dump
- - The gene's mode of inheritance could not be found
- - An AF threshold for the specific mode of inheritance could not be found in the config file
+    - The gene could not be found in the PanelApp dump
+    - The gene's mode of inheritance could not be found
+    - An AF threshold for the specific mode of inheritance could not be found in the config file
 
 If the variant is not prioritised, the reason will be added to the `Filter_reason` INFO field.
 
@@ -22,7 +22,7 @@ Optimised filtering uses:
 
 ## Requirements
 - bcftools
- - bcftools +split-vep
+    - bcftools +split-vep
 
 A config JSON file is required, which is given as an argument to the tool as a DNAnexus file ID: Example config:
 
@@ -70,7 +70,7 @@ arguments:
 ```
 
 
-For example:
+Example:
 ```
 python3 add_optimised_filtering.py \
 -i X123456_markdup_recalibrated_Haplotyper_annotated.vcf.gz \

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ A flag which might be given to a variant:
  - The gene's mode of inheritance could not be found
  - An AF threshold for the specific mode of inheritance could not be found in the config file
 
+If the variant is not prioritised, the reason will be added to the `Filter_reason` INFO field.
+
 Optimised filtering uses:
 - [bcftools](https://samtools.github.io/bcftools/bcftools.html, "bcftools website")
 - [pysam](https://pysam.readthedocs.io/en/latest/, "pysam documentation")

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ Optimised filtering is a tool used to add a flag to variants which:
  - E.g. a biallelic gene requires at least 1 homozygous variant or at least 2 heterozygous variants
 
 ## Description
+A flag which might be given to a variant:
+- `PRIORITISED`: The variant passes filtering
+- `NOT_PRIORITISED`: The variant does not pass filtering
+- `NOT_ASSESSED`: The variant has not been assessed, either because:
+ - The gene could not be found in the PanelApp dump
+ - The gene's mode of inheritance could not be found
+ - An AF threshold for the specific mode of inheritance could not be found in the config file
+
 Optimised filtering uses:
 - [bcftools](https://samtools.github.io/bcftools/bcftools.html, "bcftools website")
 - [pysam](https://pysam.readthedocs.io/en/latest/, "pysam documentation")
@@ -46,4 +54,21 @@ A config JSON file is required, which is given as an argument to the tool as a D
 ```
 
 ## Usage
-`python3 add_optimised_filtering.py -i <vcf> -c <config-file-id> -p <panel_string> -g <genepanels-file-id> -d <panelapp-dump-file-id>`
+The tool can be run as follows:
+```
+python3 add_optimised_filtering.py \
+-i <vcf> -c <config-file-id> \
+-p <panel_string> \
+-g <genepanels-file-id> \
+-d <panelapp-dump-file-id>
+```
+
+For example:
+```
+python3 add_optimised_filtering.py \
+-i X123456_markdup_recalibrated_Haplotyper_annotated.vcf.gz \
+-c project-GVqVPk04p65vjXb2kj6FqFKf:file-GYfv8V84p65bxXp1G8k5g44j \
+-p 'R149.1_Severe early-onset obesity_P' \
+-g project-GVqVPk04p65vjXb2kj6FqFKf:file-GY4QyKj4p65jx1xJqZKXBV79 \
+-d project-GVqVPk04p65vjXb2kj6FqFKf:file-GY4QxJ04p65zJf3937y01XBP
+```

--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
 # optimised_filtering
+Optimised filtering is a tool used to add a flag to variants which:
+- Pass standard filtering with bcftools
+- Are within gnomAD AF thresholds based on the gene's MOI (from PanelApp)
+- Fit the required zygosity counts (of those passing AF thresholds based on the gene's MOI)
+ - E.g. a biallelic gene requires at least 1 homozygous variant or at least 2 heterozygous variants
+
+## Description
+Optimised filtering uses:
+- [bcftools](https://samtools.github.io/bcftools/bcftools.html, "bcftools website")
+- [pysam](https://pysam.readthedocs.io/en/latest/, "pysam documentation")
+
+## Requirements
+- bcftools
+ - bcftools +split-vep
+
+A config JSON file is required, which is given as an argument to the tool as a DNAnexus file ID: Example config:
+
+```JSON
+{
+	"flag_name": "G2P",
+	"filtering_rules": {
+		"biallelic": {
+			"af": 0.005,
+			"HET": 2,
+			"HOM": 1
+		},
+		"monoallelic": {
+			"af": 0.0001,
+			"HET": 1,
+			"HOM": 1
+		},
+		"both_monoallelic_and_biallelic": {
+			"af": 0.005,
+			"HET": 1,
+			"HOM": 1
+		},
+		"standard_filtering": {
+			"af": 0.01,
+			"HET": 1,
+			"HOM": 1
+		}
+	},
+	"bcftools_filter_string": "bcftools filter --soft-filter \"EXCLUDE\" -m + -e '(CSQ_Consequence~\"synonymous_variant\" | CSQ_Consequence~\"intron_variant\" | CSQ_Consequence~\"upstream_gene_variant\" | CSQ_Consequence~\"downstream_gene_variant\" | CSQ_Consequence~\"intergenic_variant\" | CSQ_Consequence~\"5_prime_UTR_variant\" | CSQ_Consequence~\"3_prime_UTR_variant\" | CSQ_gnomADe_AF>0.01 | CSQ_gnomADg_AF>0.01 | CSQ_TWE_AF>0.05) & CSQ_ClinVar_CLNSIGCONF!~ \"pathogenic\/i\" & (CSQ_SpliceAI_pred_DS_AG<0.2 | CSQ_SpliceAI_pred_DS_AG==\".\") & (CSQ_SpliceAI_pred_DS_AL<0.2 | CSQ_SpliceAI_pred_DS_AL==\".\") & (CSQ_SpliceAI_pred_DS_DG<0.2 | CSQ_SpliceAI_pred_DS_DG==\".\") & (CSQ_SpliceAI_pred_DS_DL<0.2 | CSQ_SpliceAI_pred_DS_DL==\".\")'"
+}
+```
+
+## Usage
+`python3 add_optimised_filtering.py -i <vcf> -c <config-file-id> -p <panel_string> -g <genepanels-file-id> -d <panelapp-dump-file-id>`

--- a/add_optimised_filtering.py
+++ b/add_optimised_filtering.py
@@ -80,26 +80,32 @@ def read_in_config(config_file_id):
         file ID of the genepanels file in DNAnexus
     rules : dict
         dict of the filtering rules for each gene MOI
-    csq_types : list
-        list of variant consequence types we want to keep
+    bcftools_filter_string : str
+        bcftools command as a string
     """
     config_contents = file_utils.read_in_json_from_dnanexus(config_file_id)
 
     return list(map(config_contents.get, [
         'flag_name', 'panelapp_file_id', 'genepanels_file_id',
-        'filtering_rules', 'csq_types'
+        'filtering_rules', 'bcftools_filter_string'
     ]))
 
 
 def main():
     args = parse_args()
-    flag_name, panelapp_file, genepanels_file, rules, csq_types = read_in_config(args.config)
-
-    # Create dictionary from the panel
+    (
+        flag_name, panelapp_file, genepanels_file, rules, filter_string
+    ) = read_in_config(args.config)
+    bcftools_filter_command = file_utils.unescape_bcftools_command(
+        filter_string
+    )
     panel_dict = panels.get_formatted_dict(
         args.panel_string, genepanels_file, panelapp_file
     )
-    vcf.add_annotation(flag_name, rules, csq_types, args.input_vcf, panel_dict)
+    vcf.add_annotation(
+        flag_name, rules, args.input_vcf, panel_dict,
+        bcftools_filter_command
+    )
 
 
 if __name__ == "__main__":

--- a/add_optimised_filtering.py
+++ b/add_optimised_filtering.py
@@ -53,7 +53,7 @@ def parse_args() -> argparse.Namespace:
         '--genepanels',
         type=str,
         required=True,
-        help="DNAnexus file ID of genepanels file with panel IDs included"
+        help="genepanels file with panel IDs included"
     )
 
     parser.add_argument(
@@ -61,7 +61,7 @@ def parse_args() -> argparse.Namespace:
         '--panel_dump',
         type=str,
         required=True,
-        help="DNAnexus file ID of PanelApp JSON dump"
+        help="PanelApp JSON dump"
     )
 
     parser.add_argument(
@@ -77,14 +77,14 @@ def parse_args() -> argparse.Namespace:
     return args
 
 
-def read_in_config(config_file_id):
+def read_in_config(file_path):
     """
-    Read in the info needed for filtering from config JSON
+    Read in the info needed for filtering from JSON config
 
     Parameters
     ----------
-    config_file_id : str
-        proj:file ID of the config file in DNAnexus
+    file_path : str
+        path of the config file
 
     Returns
     -------
@@ -95,7 +95,7 @@ def read_in_config(config_file_id):
     bcftools_filter_string : str
         bcftools command as a string
     """
-    config_contents = file_utils.read_in_json_from_dnanexus(config_file_id)
+    config_contents = file_utils.read_in_json(file_path)
 
     return list(map(config_contents.get, [
         'flag_name', 'filtering_rules', 'bcftools_filter_string'

--- a/add_optimised_filtering.py
+++ b/add_optimised_filtering.py
@@ -49,6 +49,22 @@ def parse_args() -> argparse.Namespace:
     )
 
     parser.add_argument(
+        '-g',
+        '--genepanels',
+        type=str,
+        required=True,
+        help="DNAnexus file ID of genepanels file with panel IDs included"
+    )
+
+    parser.add_argument(
+        '-d',
+        '--panel_dump',
+        type=str,
+        required=True,
+        help="DNAnexus file ID of PanelApp JSON dump"
+    )
+
+    parser.add_argument(
         '-w',
         '--whitelist',
         type=str,
@@ -74,10 +90,6 @@ def read_in_config(config_file_id):
     -------
     flag_name : str
         name of the flag to be added
-    panelapp_file : str
-        file ID of the PanelApp dump in DNAnexus
-    genepanels_file : str
-        file ID of the genepanels file in DNAnexus
     rules : dict
         dict of the filtering rules for each gene MOI
     bcftools_filter_string : str
@@ -86,21 +98,18 @@ def read_in_config(config_file_id):
     config_contents = file_utils.read_in_json_from_dnanexus(config_file_id)
 
     return list(map(config_contents.get, [
-        'flag_name', 'panelapp_file_id', 'genepanels_file_id',
-        'filtering_rules', 'bcftools_filter_string'
+        'flag_name', 'filtering_rules', 'bcftools_filter_string'
     ]))
 
 
 def main():
     args = parse_args()
-    (
-        flag_name, panelapp_file, genepanels_file, rules, filter_string
-    ) = read_in_config(args.config)
+    flag_name, rules, filter_string = read_in_config(args.config)
     bcftools_filter_command = file_utils.unescape_bcftools_command(
         filter_string
     )
     panel_dict = panels.get_formatted_dict(
-        args.panel_string, genepanels_file, panelapp_file
+        args.panel_string, args.genepanels, args.panel_dump
     )
     vcf.add_annotation(
         flag_name, rules, args.input_vcf, panel_dict,

--- a/extra_scripts/check_routine_filtered_variants.py
+++ b/extra_scripts/check_routine_filtered_variants.py
@@ -1,5 +1,5 @@
 """
-This script creates a CSV for each sample describing the GM number, X number,
+This script creates a CSV for all samples describing the GM number, X number,
 report outcome and the number of variants which would be returned to scientists
 with current routine filtering methods
 """
@@ -59,7 +59,7 @@ def get_number_of_routine_variants():
     ) as f:
         lines = f.readlines()
 
-    stripped = [line.replace("\n"," ").strip() for line in lines]
+    stripped = [line.replace("\n","").strip() for line in lines]
     # Group the two lines together which are the file name and the number of
     # variants
     grouped = [stripped[i:i+2] for i in range(0, len(stripped), 2)]

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -11,38 +11,23 @@ from pathlib import Path
 ROOT_DIR = Path(__file__).absolute().parents[1]
 
 
-def read_in_json_from_local_file(folder, file_name):
+def read_in_json(file_name):
     """
-    Read in a JSON file
+    Read in a JSON file to a dict
 
+    Parameters
+    ----------
+    file_name : str
+        name of JSON file to read in
     Returns
     -------
     json_dict : dict
         the JSON converted to a Python dictionary
     """
-    with open(
-        ROOT_DIR.joinpath(folder, file_name), "r", encoding='utf8'
-    ) as json_file:
+    with open(file_name, "r", encoding='utf8') as json_file:
         json_dict = json.load(json_file)
 
     return json_dict
-
-
-def read_in_json_from_dnanexus(file_id):
-    """
-    Read in a JSON file from DNAnexus
-
-    Returns
-    -------
-    json_dict : dict
-        the JSON converted to a Python dictionary
-    """
-    proj_id, file_id = file_id.split(":")
-
-    with dx.open_dxfile(file_id, project=proj_id) as json_file:
-        json_contents = json.load(json_file)
-
-    return json_contents
 
 
 def write_out_json(folder, file_name, dict_to_write_out) -> None:

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -99,6 +99,5 @@ def unescape_bcftools_command(bcftools_filter_command):
     unescaped_command : str
         full unescaped bcftools filter command
     """
-    unescaped_command = json.loads(json.dumps(bcftools_filter_command))
 
-    return unescaped_command
+    return json.loads(json.dumps(bcftools_filter_command))

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -72,7 +72,7 @@ def read_in_csv(folder, file_name):
     ----------
     folder : str
         name of folder spreadsheet is saved in
-    file_name : _type_
+    file_name : str
         name of spreadsheet
 
     Returns
@@ -82,3 +82,23 @@ def read_in_csv(folder, file_name):
     """
 
     return pd.read_csv(ROOT_DIR.joinpath(folder, file_name))
+
+
+def unescape_bcftools_command(bcftools_filter_command):
+    """
+    Removes extra backslashes from bcftools filter command because
+    it has to be escaped in the JSON
+
+    Parameters
+    ----------
+    bcftools_filter_command : str
+        full escaped bcftools filter command directly from JSON
+
+    Returns
+    -------
+    unescaped_command : str
+        full unescaped bcftools filter command
+    """
+    unescaped_command = json.loads(json.dumps(bcftools_filter_command))
+
+    return unescaped_command

--- a/utils/vcf.py
+++ b/utils/vcf.py
@@ -404,6 +404,6 @@ def add_annotation(
     final_vcf = bcftools_remove_csq_annotation(flagged_vcf)
     bgzip(final_vcf)
     os.remove(split_vcf)
-    #os.remove(filter_vcf)
+    os.remove(filter_vcf)
     os.remove(flagged_vcf)
     os.remove(final_vcf)

--- a/utils/vcf.py
+++ b/utils/vcf.py
@@ -234,7 +234,7 @@ def add_filtering_flag(
         variants_passing_af_filter = []
         for variant in variant_list:
             if variant.filter.keys()[0] == 'PASS':
-                if (gene_present) and (gene_moi) and (af_threshold):
+                if all([gene_present, gene_moi, af_threshold]):
 
                     exome_af = variant.info['CSQ_gnomADe_AF'][0]
                     genome_af = variant.info['CSQ_gnomADg_AF'][0]
@@ -264,6 +264,13 @@ def add_filtering_flag(
                 [genotype for genotype in variant.samples[sample_name]['GT']]
                 for variant in variants_passing_af_filter
             ]
+
+            # Check no presence of GT including 2 or above to ensure
+            # multiallelics have been decomposed
+            assert all([all(x < 2 for x in gtype) for gtype in gtypes]), (
+                "Multiallelic variants have not been decomposed"
+            )
+
             # Create list of a count of 1 for each variant
             gt_counts = [genotype.count(1) for genotype in gtypes]
             count_het_homs = Counter(gt_counts)
@@ -397,6 +404,6 @@ def add_annotation(
     final_vcf = bcftools_remove_csq_annotation(flagged_vcf)
     bgzip(final_vcf)
     os.remove(split_vcf)
-    os.remove(filter_vcf)
+    #os.remove(filter_vcf)
     os.remove(flagged_vcf)
     os.remove(final_vcf)

--- a/utils/vcf.py
+++ b/utils/vcf.py
@@ -256,7 +256,7 @@ def add_filtering_flag(
                     variant.info['Filter_reason'] = 'Gene_info_not_available'
             else:
                 variant.info[flag_name] = 'NOT_PRIORITISED'
-                variant.info['Filter_reason'] = 'BCFtools_filtered'
+                variant.info['Filter_reason'] = 'bcftools_filtered'
 
         # If any variants pass filters for the gene's MOI, get genotypes of all
         if variants_passing_af_filter:


### PR DESCRIPTION
- Updated to take file IDs of genepanels and PanelApp dump as input arguments rather than in config
- Changed code to first perform standard filtering with bcftools (the filter command is now included in config)
- Changed flag of a variant to be either PRIORITISED, NOT_PRIORITISED or NOT_ASSESSED
- Added INFO field with reason if variant is not prioritised
- Removed intermediate VCFs
- Added README with explanation of flags, config and usage

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/optimised_filtering/2)
<!-- Reviewable:end -->
